### PR TITLE
Update jobs to new python server side API; update gradlew to 7.2.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jobs/by/by-bench-no-nulls-30m.json
+++ b/jobs/by/by-bench-no-nulls-30m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-30m'",
                       "bench_name = 'by-bench-' + tag",
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet')",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet')",
                   "timed" : 1
               },
 

--- a/jobs/by/comboby-2col-100m-inc.json
+++ b/jobs/by/comboby-2col-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'comboby-2col-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id', 'Values')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/comboby-2col-100m-static.json
+++ b/jobs/by/comboby-2col-100m-static.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'comboby-2col-static'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id', 'Values')"
 		  ],
                   "timed" : 1
               },

--- a/jobs/by/comboby-adjective-100m-inc.json
+++ b/jobs/by/comboby-adjective-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'comboby-adjective-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'Values')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/comboby-adjective-100m-static.json
+++ b/jobs/by/comboby-adjective-100m-static.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'comboby-adjective-static'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'Values')"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/comboby-animal-100m-inc.json
+++ b/jobs/by/comboby-animal-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'comboby-animal-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/comboby-animal-100m-static.json
+++ b/jobs/by/comboby-animal-100m-static.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'comboby-animal-static'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/comboby-manykeys-100m-inc.json
+++ b/jobs/by/comboby-manykeys-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'comboby-manykeys-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-            	      "relation = pt.readTable('/data/relation-manykeys-100m.parquet').select('key1', 'Values')",
+            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1', 'Values')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/comboby-manykeys-100m-static.json
+++ b/jobs/by/comboby-manykeys-100m-static.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'comboby-manykeys-static'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-            	      "relation = pt.readTable('/data/relation-manykeys-100m.parquet').select('key1', 'Values')"
+            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1', 'Values')"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/comboby-plant-100m-inc.json
+++ b/jobs/by/comboby-plant-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'comboby-plant-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('plant_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('plant_id', 'Values')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/comboby-plant-100m-static.json
+++ b/jobs/by/comboby-plant-100m-static.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'comboby-plant-static'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('plant_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('plant_id', 'Values')"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/combosum-2col-100m-inc.json
+++ b/jobs/by/combosum-2col-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'combosum-2col-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id', 'Values')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/combosum-2col-100m-static.json
+++ b/jobs/by/combosum-2col-100m-static.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'combosum-2col-static'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id', 'Values')"
 		  ],
                   "timed" : 1
               },

--- a/jobs/by/combosum-adjective-100m-inc.json
+++ b/jobs/by/combosum-adjective-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'combosum-adjective-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'Values')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/combosum-adjective-100m-static.json
+++ b/jobs/by/combosum-adjective-100m-static.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'combosum-adjective-static'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'Values')"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/combosum-animal-100m-inc.json
+++ b/jobs/by/combosum-animal-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'combosum-animal-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/combosum-animal-100m-static.json
+++ b/jobs/by/combosum-animal-100m-static.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'combosum-animal-static'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/combosum-manykeys-100m-inc.json
+++ b/jobs/by/combosum-manykeys-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'combosum-manykeys-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-            	      "relation = pt.readTable('/data/relation-manykeys-100m.parquet').select('key1', 'Values')",
+            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1', 'Values')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/combosum-manykeys-100m-static.json
+++ b/jobs/by/combosum-manykeys-100m-static.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'combosum-manykeys-static'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-            	      "relation = pt.readTable('/data/relation-manykeys-100m.parquet').select('key1', 'Values')"
+            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1', 'Values')"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/combosum-plant-100m-inc.json
+++ b/jobs/by/combosum-plant-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'combosum-plant-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('plant_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('plant_id', 'Values')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/combosum-plant-100m-static.json
+++ b/jobs/by/combosum-plant-100m-static.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'combosum-plant-static'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('plant_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('plant_id', 'Values')"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/countby-2col-100m-inc.json
+++ b/jobs/by/countby-2col-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'countby-2col-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/countby-2col-100m-static.json
+++ b/jobs/by/countby-2col-100m-static.json
@@ -9,7 +9,7 @@
             "title" : "preamble",
             "text" : [
               "import time",
-              "import deephaven.ParquetTools as pt",
+              "import deephaven.parquet as pt",
               "tag = 'no-nulls-100m'",
               "bench_name = 'countby2-2col-static'"
             ],
@@ -18,7 +18,7 @@
 
           {
             "title" : "load tables",
-            "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'adjective_id')",
+            "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'adjective_id')",
             "timed" : 1
           },
 

--- a/jobs/by/countby-adjective-100m-inc.json
+++ b/jobs/by/countby-adjective-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'countby-adjective-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('adjective_id')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/countby-adjective-100m-static.json
+++ b/jobs/by/countby-adjective-100m-static.json
@@ -9,7 +9,7 @@
             "title" : "preamble",
             "text" : [
               "import time",
-              "import deephaven.ParquetTools as pt",
+              "import deephaven.parquet as pt",
               "tag = 'no-nulls-100m'",
               "bench_name = 'countby-adjective-static'"
             ],
@@ -18,7 +18,7 @@
 
           {
             "title" : "load tables",
-            "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('adjective_id')",
+            "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id')",
             "timed" : 1
           },
 

--- a/jobs/by/countby-animal-100m-inc.json
+++ b/jobs/by/countby-animal-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'countby-animal-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('animal_id')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/countby-animal-100m-static.json
+++ b/jobs/by/countby-animal-100m-static.json
@@ -9,7 +9,7 @@
             "title" : "preamble",
             "text" : [
               "import time",
-              "import deephaven.ParquetTools as pt",
+              "import deephaven.parquet as pt",
               "tag = 'no-nulls-100m'",
               "bench_name = 'countby-animal-static'"
             ],
@@ -18,7 +18,7 @@
 
           {
             "title" : "load tables",
-            "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('animal_id')",
+            "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id')",
             "timed" : 1
           },
 

--- a/jobs/by/countby-filter-manykeys-100m-inc.json
+++ b/jobs/by/countby-filter-manykeys-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'countby-filter-manykeys-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-            	      "relation = pt.readTable('/data/relation-manykeys-100m.parquet').select('key1', 'Values')",
+            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1', 'Values')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/countby-filter-manykeys-100m-repeat.json
+++ b/jobs/by/countby-filter-manykeys-100m-repeat.json
@@ -9,7 +9,7 @@
             "title" : "preamble",
             "text" : [
               "import time",
-              "import deephaven.ParquetTools as pt",
+              "import deephaven.parquet as pt",
               "tag = 'no-nulls-100m'",
               "bench_name = 'countby-filter-manykeys-repeat'"
             ],
@@ -18,7 +18,7 @@
 
           {
             "title" : "load tables",
-            "text" : "relation = pt.readTable('/data/relation-manykeys-100m.parquet').select('key1', 'Values')",
+            "text" : "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1', 'Values')",
             "timed" : 1
           },
 

--- a/jobs/by/countby-filter-manykeys-100m-static.json
+++ b/jobs/by/countby-filter-manykeys-100m-static.json
@@ -9,7 +9,7 @@
             "title" : "preamble",
             "text" : [
               "import time",
-              "import deephaven.ParquetTools as pt",
+              "import deephaven.parquet as pt",
               "tag = 'no-nulls-100m'",
               "bench_name = 'countby-filter-manykeys-static'"
             ],
@@ -18,7 +18,7 @@
 
           {
             "title" : "load tables",
-            "text" : "relation = pt.readTable('/data/relation-manykeys-100m.parquet').select('key1', 'Values')",
+            "text" : "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1', 'Values')",
             "timed" : 1
           },
 

--- a/jobs/by/countby-manykeys-100m-inc.json
+++ b/jobs/by/countby-manykeys-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'countby-manykeys-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-            	      "relation = pt.readTable('/data/relation-manykeys-100m.parquet').select('key1')",
+            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/countby-manykeys-100m-repeat.json
+++ b/jobs/by/countby-manykeys-100m-repeat.json
@@ -9,7 +9,7 @@
             "title" : "preamble",
             "text" : [
               "import time",
-              "import deephaven.ParquetTools as pt",
+              "import deephaven.parquet as pt",
               "tag = 'no-nulls-100m'",
               "bench_name = 'countby-manykeys-repeat'"
             ],
@@ -18,7 +18,7 @@
 
           {
             "title" : "load tables",
-            "text" : "relation = pt.readTable('/data/relation-manykeys-100m.parquet').select('key1')",
+            "text" : "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1')",
             "timed" : 1
           },
 

--- a/jobs/by/countby-manykeys-100m-static.json
+++ b/jobs/by/countby-manykeys-100m-static.json
@@ -9,7 +9,7 @@
             "title" : "preamble",
             "text" : [
               "import time",
-              "import deephaven.ParquetTools as pt",
+              "import deephaven.parquet as pt",
               "tag = 'no-nulls-100m'",
               "bench_name = 'countby-manykeys-static'"
             ],
@@ -18,7 +18,7 @@
 
           {
             "title" : "load tables",
-            "text" : "relation = pt.readTable('/data/relation-manykeys-100m.parquet').select('key1')",
+            "text" : "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1')",
             "timed" : 1
           },
 

--- a/jobs/by/countby-plant-100m-inc.json
+++ b/jobs/by/countby-plant-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'countby-plant-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('plant_id')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('plant_id')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/countby-plant-100m-static.json
+++ b/jobs/by/countby-plant-100m-static.json
@@ -9,7 +9,7 @@
             "title" : "preamble",
             "text" : [
               "import time",
-              "import deephaven.ParquetTools as pt",
+              "import deephaven.parquet as pt",
               "tag = 'no-nulls-100m'",
               "bench_name = 'countby-plant-static'"
             ],
@@ -18,7 +18,7 @@
 
           {
             "title" : "load tables",
-            "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('plant_id')",
+            "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('plant_id')",
             "timed" : 1
           },
 

--- a/jobs/by/sumby-2col-100m-inc.json
+++ b/jobs/by/sumby-2col-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'sumby-2col-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id', 'Values')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/sumby-2col-100m-static.json
+++ b/jobs/by/sumby-2col-100m-static.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'sumby-2col-static'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id', 'Values')"
 		  ],
                   "timed" : 1
               },

--- a/jobs/by/sumby-adjective-100m-inc.json
+++ b/jobs/by/sumby-adjective-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'sumby-adjective-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'Values')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/sumby-adjective-100m-static.json
+++ b/jobs/by/sumby-adjective-100m-static.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'sumby-adjective-static'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'Values')"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/sumby-animal-100m-inc.json
+++ b/jobs/by/sumby-animal-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'sumby-animal-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/sumby-animal-100m-static.json
+++ b/jobs/by/sumby-animal-100m-static.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'sumby-animal-static'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/sumby-bench-no-nulls-100m-static-repeat.json
+++ b/jobs/by/sumby-bench-no-nulls-100m-static-repeat.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'sumby-bench-' + tag + '-static-repeat'"
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')",
                   "timed" : 1
               },
 

--- a/jobs/by/sumby-bench-no-nulls-100m-static.json
+++ b/jobs/by/sumby-bench-no-nulls-100m-static.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'sumby-animal-static'"
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')",
                   "timed" : 1
               },
 

--- a/jobs/by/sumby-manykeys-100m-inc.json
+++ b/jobs/by/sumby-manykeys-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'sumby-manykeys-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-            	      "relation = pt.readTable('/data/relation-manykeys-100m.parquet').select('key1', 'Values')",
+            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1', 'Values')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/sumby-manykeys-100m-static.json
+++ b/jobs/by/sumby-manykeys-100m-static.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'sumby-manykeys-static'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-            	      "relation = pt.readTable('/data/relation-manykeys-100m.parquet').select('key1', 'Values')"
+            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1', 'Values')"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/sumby-plant-100m-inc.json
+++ b/jobs/by/sumby-plant-100m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'sumby-plant-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('plant_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('plant_id', 'Values')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/by/sumby-plant-100m-static.json
+++ b/jobs/by/sumby-plant-100m-static.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'sumby-plant-static'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('plant_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('plant_id', 'Values')"
                   ],
                   "timed" : 1
               },

--- a/jobs/comboagg/comboagg-bench-no-nulls-100m.json
+++ b/jobs/comboagg/comboagg-bench-no-nulls-100m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "from deephaven import Aggregation as agg, as_list",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'comboagg-bench-' + tag",
@@ -19,7 +19,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + tag + '.parquet').view('animal_id', 'adjective_id')",
+                  "text" : "relation = pt.read('/data/relation-' + tag + '.parquet').view('animal_id', 'adjective_id')",
                   "timed" : 1
               },
 

--- a/jobs/readtable-select/readtable-select-100m.json
+++ b/jobs/readtable-select/readtable-select-100m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'select-view-bench-' + tag"
                   ],
@@ -26,7 +26,7 @@
                   "title" : "read table into memory",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = pt.readTable('/data/relation-' + str(tag) + '.parquet').select()",
+                      "result = pt.read('/data/relation-' + str(tag) + '.parquet').select()",
                       "time_end_ns = time.perf_counter_ns()",
                       "processed_rows = result.size()"
                   ],

--- a/jobs/select-by/select-by-bench-no-nulls-100m.json
+++ b/jobs/select-by/select-by-bench-no-nulls-100m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'select-by-bench-' + tag",
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'adjective_id')",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'adjective_id')",
                   "timed" : 1
               },
 

--- a/jobs/select-by/select-by-bench-no-nulls-30m.json
+++ b/jobs/select-by/select-by-bench-no-nulls-30m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-30m'",
                       "bench_name = 'select-by-bench-' + tag",
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'adjective_id')",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'adjective_id')",
                   "timed" : 1
               },
 

--- a/jobs/select-comboagg/select-comboagg-bench-no-nulls-100m.json
+++ b/jobs/select-comboagg/select-comboagg-bench-no-nulls-100m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "from deephaven import Aggregation as agg, as_list",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'select-comboagg-bench-' + tag",
@@ -19,7 +19,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + tag + '.parquet').select('animal_id', 'adjective_id')",
+                  "text" : "relation = pt.read('/data/relation-' + tag + '.parquet').select('animal_id', 'adjective_id')",
                   "timed" : 1
               },
 

--- a/jobs/select-sort/select-sort-bench-1col-no-nulls-20m.json
+++ b/jobs/select-sort/select-sort-bench-1col-no-nulls-20m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-20m'",
                       "bench_name = 'select-sort-bench-1col-' + tag",
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select()",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select()",
                   "timed" : 1
               },
 

--- a/jobs/select-sort/select-sort-bench-no-nulls-10m.json
+++ b/jobs/select-sort/select-sort-bench-no-nulls-10m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'select-sort-bench-' + tag",
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').head(10_000_000).view('animal_id', 'adjective_id').select()",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').head(10_000_000).view('animal_id', 'adjective_id').select()",
                   "timed" : 1
               },
 

--- a/jobs/select-update/select-update-bench-no-nulls-100m.json
+++ b/jobs/select-update/select-update-bench-no-nulls-100m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'select-update-bench-' + tag",
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select()",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select()",
                   "timed" : 1
               },
 

--- a/jobs/select-update/select-update-bench-no-nulls-8-cols-100m.json
+++ b/jobs/select-update/select-update-bench-no-nulls-8-cols-100m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-8-cols-100m'",
                       "bench_name = 'select-update-bench-' + tag",
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-no-nulls-100m.parquet').select()",
+                  "text" : "relation = pt.read('/data/relation-no-nulls-100m.parquet').select()",
                   "timed" : 1
               },
 

--- a/jobs/select-view/select-view-bench-no-nulls-100m.json
+++ b/jobs/select-view/select-view-bench-no-nulls-100m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'select-view-bench-' + tag",
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select()",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select()",
                   "timed" : 1
               },
 

--- a/jobs/select-where/select-where-bench-100m.json
+++ b/jobs/select-where/select-where-bench-100m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = '100m'",
                       "bench_name = 'select-where-bench-' + tag",
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select()",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select()",
                   "timed" : 1
               },
 

--- a/jobs/select-where/select-where-bench-30m.json
+++ b/jobs/select-where/select-where-bench-30m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = '30m'",
                       "bench_name = 'select-where-bench-' + tag",
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select()",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select()",
                   "timed" : 1
               },
 

--- a/jobs/select-where/select-where-bench-no-nulls-100m.json
+++ b/jobs/select-where/select-where-bench-no-nulls-100m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'select-where-bench-' + tag",
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select()",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select()",
                   "timed" : 1
               },
 

--- a/jobs/select-where/select-where-bench-no-nulls-30m.json
+++ b/jobs/select-where/select-where-bench-no-nulls-30m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-30m'",
                       "bench_name = 'select-where-bench-' + tag",
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet').select()",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select()",
                   "timed" : 1
               },
 

--- a/jobs/sort/sort-bench-no-nulls-100m.json
+++ b/jobs/sort/sort-bench-no-nulls-100m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'sort-bench-' + tag",
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet')",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet')",
                   "timed" : 1
               },
 

--- a/jobs/sort/sort-bench-no-nulls-10m-inc.json
+++ b/jobs/sort/sort-bench-no-nulls-10m-inc.json
@@ -15,7 +15,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-10m-inc'",
                       "bench_name = 'sort-bench-' + tag + '-inc'"
                   ],
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-no-nulls-100m.parquet').head(10000000)",
+                      "relation = pt.read('/data/relation-no-nulls-100m.parquet').head(10000000)",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"

--- a/jobs/sort/sort-bench-no-nulls-10m-static-repeat.json
+++ b/jobs/sort/sort-bench-no-nulls-10m-static-repeat.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-10m-static-repeat'",
                       "bench_name = 'sort-bench-' + tag"
                   ],
@@ -19,7 +19,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-no-nulls-100m.parquet').head(10000000)"
+                      "relation = pt.read('/data/relation-no-nulls-100m.parquet').head(10000000)"
                   ],
                   "timed" : 1
               },

--- a/jobs/sort/sort-bench-no-nulls-10m-static.json
+++ b/jobs/sort/sort-bench-no-nulls-10m-static.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-10m-static'",
                       "bench_name = 'sort-bench-' + tag"
                   ],
@@ -19,7 +19,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.readTable('/data/relation-no-nulls-100m.parquet').head(10000000)",
+                      "relation = pt.read('/data/relation-no-nulls-100m.parquet').head(10000000)",
                   ],
                   "timed" : 1
               },

--- a/jobs/update/update-bench-no-nulls-100m.json
+++ b/jobs/update/update-bench-no-nulls-100m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'update-bench-' + tag",
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet')",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet')",
                   "timed" : 1
               },
 

--- a/jobs/update/update-bench-no-nulls-8-cols-100m.json
+++ b/jobs/update/update-bench-no-nulls-8-cols-100m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-8-cols-100m'",
                       "bench_name = 'update-bench-' + tag",
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-no-nulls-100m.parquet')",
+                  "text" : "relation = pt.read('/data/relation-no-nulls-100m.parquet')",
                   "timed" : 1
               },
 

--- a/jobs/view/view-bench-no-nulls-100m.json
+++ b/jobs/view/view-bench-no-nulls-100m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'view-bench-' + tag",
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet')",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet')",
                   "timed" : 1
               },
 

--- a/jobs/where/where-bench-100m.json
+++ b/jobs/where/where-bench-100m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = '100m'",
                       "bench_name = 'where-bench-' + tag",
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet')",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet')",
                   "timed" : 1
               },
 

--- a/jobs/where/where-bench-include-nulls-100m.json
+++ b/jobs/where/where-bench-include-nulls-100m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = '100m'",
                       "bench_name = 'where-bench-' + tag",
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet')",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet')",
                   "timed" : 1
               },
 

--- a/jobs/where/where-bench-no-nulls-100m.json
+++ b/jobs/where/where-bench-no-nulls-100m.json
@@ -9,7 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
-                      "import deephaven.ParquetTools as pt",
+                      "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'where-bench-' + tag",
                   ],
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.readTable('/data/relation-' + str(tag) + '.parquet')",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet')",
                   "timed" : 1
               },
 


### PR DESCRIPTION
Job files where changed with this shell snippet:

```
find . -type f | xgrep -l 'import deephaven.ParquetTools' | while read F; do sed -i -e 's/deephaven\.ParquetTools/deephaven.parquet/g'  -e 's/\.readTable/.read/g' $F; echo $F; done
```