### PR TITLE
Tested and fixed many broken bencher tests

### DIFF
--- a/jobs/aj/aj-bench-no-nulls-100m-1m.json
+++ b/jobs/aj/aj-bench-no-nulls-100m-1m.json
@@ -18,9 +18,9 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "from deephaven.ParquetTools import readTable", 
-                      "workqueue = readTable('/data/workqueue-no-nulls-100m.parquet')",
-                      "auditqueue = readTable('/data/auditqueue-no-nulls-1m.parquet')",
+                      "from deephaven.parquet import read", 
+                      "workqueue = read('/data/workqueue-no-nulls-100m.parquet')",
+                      "auditqueue = read('/data/auditqueue-no-nulls-1m.parquet')",
                   ],
                   "timed" : 1
               },
@@ -35,7 +35,7 @@
                   "title" : "perform aj",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = workqueue.aj(auditqueue, 'user_id, timestamp', 'audit_timestamp = timestamp')",
+                      "result = workqueue.aj(auditqueue, on=['user_id', 'timestamp'], joins=['audit_timestamp = timestamp'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/aj/aj-bench-no-nulls-1m-100m.json
+++ b/jobs/aj/aj-bench-no-nulls-1m-100m.json
@@ -18,9 +18,9 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "from deephaven.ParquetTools import readTable", 
-                      "workqueue = readTable('/data/workqueue-no-nulls-100m.parquet')",
-                      "auditqueue = readTable('/data/auditqueue-no-nulls-1m.parquet')",
+                      "from deephaven.parquet import read", 
+                      "workqueue = read('/data/workqueue-no-nulls-100m.parquet')",
+                      "auditqueue = read('/data/auditqueue-no-nulls-1m.parquet')",
                   ],
                   "timed" : 1
               },
@@ -35,7 +35,7 @@
                   "title" : "perform aj",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = auditqueue.aj(workqueue, 'user_id, timestamp', 'work_timestamp = timestamp')",
+                      "result = auditqueue.aj(workqueue, on=['user_id', 'timestamp'], joins=['work_timestamp = timestamp'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/aj/aj-bench-no-nulls-no-by-100m-1m.json
+++ b/jobs/aj/aj-bench-no-nulls-no-by-100m-1m.json
@@ -18,9 +18,9 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "from deephaven.ParquetTools import readTable", 
-                      "workqueue = readTable('/data/workqueue-no-nulls-100m.parquet')",
-                      "auditqueue = readTable('/data/auditqueue-no-nulls-1m.parquet')",
+                      "from deephaven.parquet import read", 
+                      "workqueue = read('/data/workqueue-no-nulls-100m.parquet')",
+                      "auditqueue = read('/data/auditqueue-no-nulls-1m.parquet')",
                   ],
                   "timed" : 1
               },
@@ -35,7 +35,7 @@
                   "title" : "perform aj",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = workqueue.aj(auditqueue, 'timestamp', 'audit_timestamp = timestamp')",
+                      "result = workqueue.aj(auditqueue, on=['timestamp'], joins=['audit_timestamp = timestamp'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/aj/aj-bench-no-nulls-no-by-1m-100m.json
+++ b/jobs/aj/aj-bench-no-nulls-no-by-1m-100m.json
@@ -18,9 +18,9 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "from deephaven.ParquetTools import readTable", 
-                      "workqueue = readTable('/data/workqueue-no-nulls-100m.parquet')",
-                      "auditqueue = readTable('/data/auditqueue-no-nulls-1m.parquet')",
+                      "from deephaven.parquet import read", 
+                      "workqueue = read('/data/workqueue-no-nulls-100m.parquet')",
+                      "auditqueue = read('/data/auditqueue-no-nulls-1m.parquet')",
                   ],
                   "timed" : 1
               },
@@ -35,7 +35,7 @@
                   "title" : "perform aj",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = auditqueue.aj(workqueue, 'timestamp', 'work_timestamp = timestamp')",
+                      "result = auditqueue.aj(workqueue, on=['timestamp'], joins=['work_timestamp = timestamp'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/by/agglist-sum.py
+++ b/jobs/by/agglist-sum.py
@@ -1,6 +1,6 @@
-from deephaven import Aggregation as agg, as_list
+from deephaven import agg
 
-agg_list = as_list([\
-    agg.AggCount("Count"),\
-    agg.AggSum("Sum = Values"),\
-    ])
+agg_list = [
+    agg.count_("Count"),
+    agg.sum_("Sum = Values"),
+]

--- a/jobs/by/agglist.py
+++ b/jobs/by/agglist.py
@@ -1,7 +1,7 @@
-from deephaven import Aggregation as agg, as_list
+from deephaven import agg
 
-agg_list = as_list([\
-    agg.AggCount("Count"),\
-    agg.AggAvg("Avg = Values"),\
-    agg.AggStd("Std = Values"),\
-    ])
+agg_list = [
+    agg.count_("Count"),
+    agg.avg("Avg = Values"),
+    agg.std("Std = Values"),
+]

--- a/jobs/by/by-bench-no-nulls-30m.json
+++ b/jobs/by/by-bench-no-nulls-30m.json
@@ -32,7 +32,7 @@
                   "title" : "perform countBy",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.view('animal_id', 'adjective_id').countBy('count', 'animal_id')",
+                      "result = relation.view(formulas=['animal_id', 'adjective_id']).count_by('count', by=['animal_id'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/by/comboby-2col-100m-inc.json
+++ b/jobs/by/comboby-2col-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['adjective_id', 'animal_id', 'Values'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -48,7 +48,7 @@
               {
                   "title" : "initialize comboBy",
                   "text" : [
-                      "result = relation_filtered.aggBy(agg_list, 'animal_id', 'adjective_id')",
+                      "result = relation_filtered.agg_by(agg_list, by=['animal_id', 'adjective_id'])",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -60,7 +60,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/comboby-2col-100m-static.json
+++ b/jobs/by/comboby-2col-100m-static.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['adjective_id', 'animal_id', 'Values'])"
 		  ],
                   "timed" : 1
               },
@@ -46,9 +46,9 @@
                   "title" : "perform comboBy",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.aggBy(agg_list, 'animal_id' , 'adjective_id')",
+                      "result = relation.agg_by(agg_list, by=['animal_id' , 'adjective_id'])",
                       "time_end_ns = time.perf_counter_ns()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/comboby-adjective-100m-inc.json
+++ b/jobs/by/comboby-adjective-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['adjective_id', 'Values'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -48,7 +48,7 @@
               {
                   "title" : "initialize comboBy",
                   "text" : [
-                      "result = relation_filtered.aggBy(agg_list, 'adjective_id')",
+                      "result = relation_filtered.agg_by(agg_list, by=['adjective_id'])",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -60,7 +60,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/comboby-adjective-100m-static.json
+++ b/jobs/by/comboby-adjective-100m-static.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['adjective_id', 'Values'])"
                   ],
                   "timed" : 1
               },
@@ -46,9 +46,9 @@
                   "title" : "perform comboBy",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.aggBy(agg_list, 'adjective_id')",
+                      "result = relation.agg_by(agg_list, by=['adjective_id'])",
                       "time_end_ns = time.perf_counter_ns()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/comboby-animal-100m-inc.json
+++ b/jobs/by/comboby-animal-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['animal_id', 'Values'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -48,7 +48,7 @@
               {
                   "title" : "initialize comboBy",
                   "text" : [
-                      "result = relation_filtered.aggBy(agg_list, 'animal_id')",
+                      "result = relation_filtered.agg_by(agg_list, by=['animal_id'])",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -60,7 +60,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/comboby-manykeys-100m-inc.json
+++ b/jobs/by/comboby-manykeys-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1', 'Values')",
+            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select(formulas=['key1', 'Values'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -48,7 +48,7 @@
               {
                   "title" : "initialize comboBy",
                   "text" : [
-                      "result = relation_filtered.aggBy(agg_list, 'key1')",
+                      "result = relation_filtered.agg_by(agg_list, by=['key1'])",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -60,7 +60,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/comboby-manykeys-100m-static.json
+++ b/jobs/by/comboby-manykeys-100m-static.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1', 'Values')"
+            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select(formulas=['key1', 'Values'])"
                   ],
                   "timed" : 1
               },
@@ -46,9 +46,9 @@
                   "title" : "perform comboBy",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.aggBy(agg_list, 'key1')",
+                      "result = relation.agg_by(agg_list, by=['key1'])",
                       "time_end_ns = time.perf_counter_ns()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/comboby-plant-100m-inc.json
+++ b/jobs/by/comboby-plant-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('plant_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['plant_id', 'Values'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -48,7 +48,7 @@
               {
                   "title" : "initialize comboBy",
                   "text" : [
-                      "result = relation_filtered.aggBy(agg_list, 'plant_id')",
+                      "result = relation_filtered.agg_by(agg_list, by=['plant_id'])",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -60,7 +60,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/comboby-plant-100m-static.json
+++ b/jobs/by/comboby-plant-100m-static.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('plant_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['plant_id', 'Values'])"
                   ],
                   "timed" : 1
               },
@@ -46,9 +46,9 @@
                   "title" : "perform comboBy",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.aggBy(agg_list, 'plant_id')",
+                      "result = relation.agg_by(agg_list, by=['plant_id'])",
                       "time_end_ns = time.perf_counter_ns()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/combosum-2col-100m-inc.json
+++ b/jobs/by/combosum-2col-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['adjective_id', 'animal_id', 'Values'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -48,7 +48,7 @@
               {
                   "title" : "initialize comboBy",
                   "text" : [
-                      "result = relation_filtered.aggBy(agg_list, 'animal_id', 'adjective_id')",
+                      "result = relation_filtered.agg_by(agg_list, by=['animal_id', 'adjective_id'])",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -60,7 +60,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/combosum-2col-100m-static.json
+++ b/jobs/by/combosum-2col-100m-static.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['adjective_id', 'animal_id', 'Values'])"
 		  ],
                   "timed" : 1
               },
@@ -46,9 +46,9 @@
                   "title" : "perform comboBy",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.aggBy(agg_list, 'animal_id' , 'adjective_id')",
+                      "result = relation.agg_by(agg_list, by=['animal_id' , 'adjective_id'])",
                       "time_end_ns = time.perf_counter_ns()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/combosum-adjective-100m-inc.json
+++ b/jobs/by/combosum-adjective-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['adjective_id', 'Values'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -48,7 +48,7 @@
               {
                   "title" : "initialize comboBy",
                   "text" : [
-                      "result = relation_filtered.aggBy(agg_list, 'adjective_id')",
+                      "result = relation_filtered.agg_by(agg_list, by=['adjective_id'])",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -60,7 +60,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/combosum-adjective-100m-static.json
+++ b/jobs/by/combosum-adjective-100m-static.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['adjective_id', 'Values'])"
                   ],
                   "timed" : 1
               },
@@ -46,9 +46,9 @@
                   "title" : "perform comboBy",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.aggBy(agg_list, 'adjective_id')",
+                      "result = relation.agg_by(agg_list, by=['adjective_id'])",
                       "time_end_ns = time.perf_counter_ns()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/combosum-animal-100m-inc.json
+++ b/jobs/by/combosum-animal-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['animal_id', 'Values'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -48,7 +48,7 @@
               {
                   "title" : "initialize comboBy",
                   "text" : [
-                      "result = relation_filtered.aggBy(agg_list, 'animal_id')",
+                      "result = relation_filtered.agg_by(agg_list, by=['animal_id'])",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -60,7 +60,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/combosum-animal-100m-static.json
+++ b/jobs/by/combosum-animal-100m-static.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['animal_id', 'Values'])"
                   ],
                   "timed" : 1
               },
@@ -46,9 +46,9 @@
                   "title" : "perform comboBy",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.aggBy(agg_list, 'animal_id')",
+                      "result = relation.agg_by(agg_list, by=['animal_id'])",
                       "time_end_ns = time.perf_counter_ns()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/combosum-manykeys-100m-inc.json
+++ b/jobs/by/combosum-manykeys-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1', 'Values')",
+            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select(formulas=['key1', 'Values'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -48,7 +48,7 @@
               {
                   "title" : "initialize comboBy",
                   "text" : [
-                      "result = relation_filtered.aggBy(agg_list, 'key1')",
+                      "result = relation_filtered.agg_by(agg_list, by=['key1'])",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -60,7 +60,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/combosum-manykeys-100m-static.json
+++ b/jobs/by/combosum-manykeys-100m-static.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1', 'Values')"
+            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select(formulas=['key1', 'Values'])"
                   ],
                   "timed" : 1
               },
@@ -46,9 +46,9 @@
                   "title" : "perform comboBy",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.aggBy(agg_list, 'key1')",
+                      "result = relation.agg_by(agg_list, by=['key1'])",
                       "time_end_ns = time.perf_counter_ns()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/combosum-plant-100m-inc.json
+++ b/jobs/by/combosum-plant-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('plant_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['plant_id', 'Values'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -48,7 +48,7 @@
               {
                   "title" : "initialize comboBy",
                   "text" : [
-                      "result = relation_filtered.aggBy(agg_list, 'plant_id')",
+                      "result = relation_filtered.agg_by(agg_list, by=['plant_id'])",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -60,7 +60,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/combosum-plant-100m-static.json
+++ b/jobs/by/combosum-plant-100m-static.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('plant_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['plant_id', 'Values'])"
                   ],
                   "timed" : 1
               },
@@ -46,9 +46,9 @@
                   "title" : "perform comboBy",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.aggBy(agg_list, 'plant_id')",
+                      "result = relation.agg_by(agg_list, by=['plant_id'])",
                       "time_end_ns = time.perf_counter_ns()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/countby-2col-100m-inc.json
+++ b/jobs/by/countby-2col-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['adjective_id', 'animal_id'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -42,7 +42,7 @@
               {
                   "title" : "initialize countBy",
                   "text" : [
-                      "result = relation_filtered.countBy('count', 'animal_id', 'adjective_id')",
+                      "result = relation_filtered.count_by('count', by=['animal_id', 'adjective_id'])",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -54,7 +54,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/countby-2col-100m-static.json
+++ b/jobs/by/countby-2col-100m-static.json
@@ -18,7 +18,7 @@
 
           {
             "title" : "load tables",
-            "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'adjective_id')",
+            "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['animal_id', 'adjective_id'])",
             "timed" : 1
           },
 
@@ -32,9 +32,9 @@
             "title" : "perform countBy",
             "text" : [
               "time_start_ns = time.perf_counter_ns()",
-              "result = relation.countBy('count', 'animal_id', 'adjective_id')",
+              "result = relation.count_by('count', by=['animal_id', 'adjective_id'])",
               "time_end_ns = time.perf_counter_ns()",
-              "processed_rows = relation.size()"
+              "processed_rows = relation.size"
             ],
             "timed" : 1
           },

--- a/jobs/by/countby-adjective-100m-inc.json
+++ b/jobs/by/countby-adjective-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['adjective_id'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -42,7 +42,7 @@
               {
                   "title" : "initialize countBy",
                   "text" : [
-                      "result = relation_filtered.countBy('count', 'adjective_id')",
+                      "result = relation_filtered.count_by('count', by=['adjective_id'])",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -54,7 +54,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/countby-adjective-100m-static.json
+++ b/jobs/by/countby-adjective-100m-static.json
@@ -18,7 +18,7 @@
 
           {
             "title" : "load tables",
-            "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id')",
+            "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['adjective_id'])",
             "timed" : 1
           },
 
@@ -32,9 +32,9 @@
             "title" : "perform countBy",
             "text" : [
               "time_start_ns = time.perf_counter_ns()",
-              "result = relation.countBy('count', 'adjective_id')",
+              "result = relation.count_by('count', by=['adjective_id'])",
               "time_end_ns = time.perf_counter_ns()",
-              "processed_rows = relation.size()"
+              "processed_rows = relation.size"
             ],
             "timed" : 1
           },

--- a/jobs/by/countby-animal-100m-inc.json
+++ b/jobs/by/countby-animal-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['animal_id'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -42,7 +42,7 @@
               {
                   "title" : "initialize sumBy",
                   "text" : [
-                      "result = relation_filtered.countBy('count', 'animal_id')",
+                      "result = relation_filtered.count_by('count', by=['animal_id'])",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -54,7 +54,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/countby-animal-100m-static.json
+++ b/jobs/by/countby-animal-100m-static.json
@@ -18,7 +18,7 @@
 
           {
             "title" : "load tables",
-            "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id')",
+            "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['animal_id'])",
             "timed" : 1
           },
 
@@ -32,9 +32,9 @@
             "title" : "perform countBy",
             "text" : [
               "time_start_ns = time.perf_counter_ns()",
-              "result = relation.countBy('count', 'animal_id')",
+              "result = relation.count_by('count', by=['animal_id'])",
               "time_end_ns = time.perf_counter_ns()",
-              "processed_rows = relation.size()"
+              "processed_rows = relation.size"
             ],
             "timed" : 1
           },

--- a/jobs/by/countby-filter-manykeys-100m-inc.json
+++ b/jobs/by/countby-filter-manykeys-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1', 'Values')",
+            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select(formulas=['key1', 'Values'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -48,7 +48,7 @@
               {
                   "title" : "initialize countBy",
                   "text" : [
-                      "result = relation_filtered.aggBy(agg_list, 'key1').where('Count % 2 == 1').dropColumns('Count', 'key1').sumBy()",
+                      "result = relation_filtered.agg_by(agg_list, by=['key1']).where('Count % 2 == 1').drop_columns(cols=['Count', 'key1']).sum_by()",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -60,7 +60,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/countby-filter-manykeys-100m-repeat.json
+++ b/jobs/by/countby-filter-manykeys-100m-repeat.json
@@ -18,7 +18,7 @@
 
           {
             "title" : "load tables",
-            "text" : "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1', 'Values')",
+            "text" : "relation = pt.read('/data/relation-manykeys-100m.parquet').select(formulas=['key1', 'Values'])",
             "timed" : 1
           },
 
@@ -44,7 +44,7 @@
             "title" : "perform countBy",
             "text" : [
 	      "def applyCount(rel):",
-              "     result = rel.aggBy(agg_list, 'key1').where('Count % 2 == 1').dropColumns('Count', 'key1').sumBy()",
+              "     result = rel.agg_by(agg_list, by=['key1']).where('Count % 2 == 1').drop_columns(cols=['Count', 'key1']).sum_by()",
 	      "doRepeat(relation, 3500000, applyCount)"
             ],
             "timed" : 1

--- a/jobs/by/countby-filter-manykeys-100m-static.json
+++ b/jobs/by/countby-filter-manykeys-100m-static.json
@@ -18,7 +18,7 @@
 
           {
             "title" : "load tables",
-            "text" : "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1', 'Values')",
+            "text" : "relation = pt.read('/data/relation-manykeys-100m.parquet').select(formulas=['key1', 'Values'])",
             "timed" : 1
           },
 
@@ -38,9 +38,9 @@
             "title" : "perform countBy",
             "text" : [
               "time_start_ns = time.perf_counter_ns()",
-              "result = relation.aggBy(agg_list, 'key1').where('Count % 2 == 1').dropColumns('Count', 'key1').sumBy()",
+              "result = relation.agg_by(agg_list, by=['key1']).where('Count % 2 == 1').drop_columns(cols=['Count', 'key1']).sum_by()",
               "time_end_ns = time.perf_counter_ns()",
-              "processed_rows = relation.size()"
+              "processed_rows = relation.size"
             ],
             "timed" : 1
           },

--- a/jobs/by/countby-manykeys-100m-inc.json
+++ b/jobs/by/countby-manykeys-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1')",
+            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select(formulas=['key1'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -42,7 +42,7 @@
               {
                   "title" : "initialize countBy",
                   "text" : [
-                      "result = relation_filtered.countBy('count', 'key1')",
+                      "result = relation_filtered.count_by('count', by=['key1'])",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -54,7 +54,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/countby-manykeys-100m-repeat.json
+++ b/jobs/by/countby-manykeys-100m-repeat.json
@@ -18,7 +18,7 @@
 
           {
             "title" : "load tables",
-            "text" : "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1')",
+            "text" : "relation = pt.read('/data/relation-manykeys-100m.parquet').select(formulas=['key1'])",
             "timed" : 1
           },
 
@@ -38,7 +38,7 @@
             "title" : "perform countBy",
             "text" : [
 	      "def applyCount(rel):",
-	      "     result = rel.countBy('count', 'key1')",
+	      "     result = rel.count_by('count', by=['key1'])",
 	      "doRepeat(relation, 3500000, applyCount)"
             ],
             "timed" : 1

--- a/jobs/by/countby-manykeys-100m-static.json
+++ b/jobs/by/countby-manykeys-100m-static.json
@@ -18,7 +18,7 @@
 
           {
             "title" : "load tables",
-            "text" : "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1')",
+            "text" : "relation = pt.read('/data/relation-manykeys-100m.parquet').select(formulas=['key1'])",
             "timed" : 1
           },
 
@@ -32,9 +32,9 @@
             "title" : "perform countBy",
             "text" : [
               "time_start_ns = time.perf_counter_ns()",
-              "result = relation.countBy('count', 'key1')",
+              "result = relation.count_by('count', by=['key1'])",
               "time_end_ns = time.perf_counter_ns()",
-              "processed_rows = relation.size()"
+              "processed_rows = relation.size"
             ],
             "timed" : 1
           },

--- a/jobs/by/countby-plant-100m-inc.json
+++ b/jobs/by/countby-plant-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('plant_id')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['plant_id'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -42,7 +42,7 @@
               {
                   "title" : "initialize countBy",
                   "text" : [
-                      "result = relation_filtered.countBy('count', 'plant_id')",
+                      "result = relation_filtered.count_by('count', by=['plant_id'])",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -54,7 +54,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/countby-plant-100m-static.json
+++ b/jobs/by/countby-plant-100m-static.json
@@ -18,7 +18,7 @@
 
           {
             "title" : "load tables",
-            "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('plant_id')",
+            "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['plant_id'])",
             "timed" : 1
           },
 
@@ -32,9 +32,9 @@
             "title" : "perform countBy",
             "text" : [
               "time_start_ns = time.perf_counter_ns()",
-              "result = relation.countBy('count', 'plant_id')",
+              "result = relation.count_by('count', by=['plant_id'])",
               "time_end_ns = time.perf_counter_ns()",
-              "processed_rows = relation.size()"
+              "processed_rows = relation.size"
             ],
             "timed" : 1
           },

--- a/jobs/by/sumby-2col-100m-inc.json
+++ b/jobs/by/sumby-2col-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['adjective_id', 'animal_id', 'Values'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -42,7 +42,7 @@
               {
                   "title" : "initialize sumBy",
                   "text" : [
-                      "result = relation_filtered.sumBy('animal_id', 'adjective_id')",
+                      "result = relation_filtered.sum_by(by=['animal_id', 'adjective_id'])",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -54,7 +54,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/sumby-2col-100m-static.json
+++ b/jobs/by/sumby-2col-100m-static.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'animal_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['adjective_id', 'animal_id', 'Values'])"
 		  ],
                   "timed" : 1
               },
@@ -40,9 +40,9 @@
                   "title" : "perform sumBy",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.sumBy('animal_id' , 'adjective_id')",
+                      "result = relation.sum_by(by=['animal_id' , 'adjective_id'])",
                       "time_end_ns = time.perf_counter_ns()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/sumby-adjective-100m-inc.json
+++ b/jobs/by/sumby-adjective-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['adjective_id', 'Values'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -42,7 +42,7 @@
               {
                   "title" : "initialize sumBy",
                   "text" : [
-                      "result = relation_filtered.sumBy('adjective_id')",
+                      "result = relation_filtered.sum_by(by=['adjective_id'])",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -54,7 +54,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/sumby-adjective-100m-static.json
+++ b/jobs/by/sumby-adjective-100m-static.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('adjective_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['adjective_id', 'Values'])"
                   ],
                   "timed" : 1
               },
@@ -40,9 +40,9 @@
                   "title" : "perform sumBy",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.sumBy('adjective_id')",
+                      "result = relation.sum_by(by=['adjective_id'])",
                       "time_end_ns = time.perf_counter_ns()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/sumby-animal-100m-inc.json
+++ b/jobs/by/sumby-animal-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['animal_id', 'Values'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -42,7 +42,7 @@
               {
                   "title" : "initialize sumBy",
                   "text" : [
-                      "result = relation_filtered.sumBy('animal_id')",
+                      "result = relation_filtered.sum_by(by=['animal_id'])",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -54,7 +54,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/sumby-animal-100m-static.json
+++ b/jobs/by/sumby-animal-100m-static.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['animal_id', 'Values'])"
                   ],
                   "timed" : 1
               },
@@ -40,9 +40,9 @@
                   "title" : "perform sumBy",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.sumBy('animal_id')",
+                      "result = relation.sum_by(by=['animal_id'])",
                       "time_end_ns = time.perf_counter_ns()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/sumby-bench-no-nulls-100m-static-repeat.json
+++ b/jobs/by/sumby-bench-no-nulls-100m-static-repeat.json
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['animal_id', 'Values'])",
                   "timed" : 1
               },
 
@@ -33,9 +33,9 @@
                   "text" : [
                       "processed_rows = 0",
                       "time_start_ns = time.perf_counter_ns()",
-                      "for headSz in range(0, relation.size(), 5000000):",
+                      "for headSz in range(0, relation.size, 5000000):",
                       "     relHead = relation.head(headSz)",
-                      "     result = relHead.sumBy('animal_id')",
+                      "     result = relHead.sum_by(by=['animal_id'])",
                       "     processed_rows += headSz",
                       "time_end_ns = time.perf_counter_ns()"
                   ],

--- a/jobs/by/sumby-bench-no-nulls-100m-static.json
+++ b/jobs/by/sumby-bench-no-nulls-100m-static.json
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'Values')",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['animal_id', 'Values'])",
                   "timed" : 1
               },
 
@@ -32,9 +32,9 @@
                   "title" : "perform sumBy",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.sumBy('animal_id')",
+                      "result = relation.sum_by(by=['animal_id'])",
                       "time_end_ns = time.perf_counter_ns()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/sumby-manykeys-100m-inc.json
+++ b/jobs/by/sumby-manykeys-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1', 'Values')",
+            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select(formulas=['key1', 'Values'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -42,7 +42,7 @@
               {
                   "title" : "initialize sumBy",
                   "text" : [
-                      "result = relation_filtered.sumBy('key1')",
+                      "result = relation_filtered.sum_by(by=['key1'])",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -54,7 +54,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/sumby-manykeys-100m-static.json
+++ b/jobs/by/sumby-manykeys-100m-static.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select('key1', 'Values')"
+            	      "relation = pt.read('/data/relation-manykeys-100m.parquet').select(formulas=['key1', 'Values'])"
                   ],
                   "timed" : 1
               },
@@ -40,9 +40,9 @@
                   "title" : "perform sumBy",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.sumBy('key1')",
+                      "result = relation.sum_by(by=['key1'])",
                       "time_end_ns = time.perf_counter_ns()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/sumby-plant-100m-inc.json
+++ b/jobs/by/sumby-plant-100m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('plant_id', 'Values')",
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['plant_id', 'Values'])",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -42,7 +42,7 @@
               {
                   "title" : "initialize sumBy",
                   "text" : [
-                      "result = relation_filtered.sumBy('plant_id')",
+                      "result = relation_filtered.sum_by(by=['plant_id'])",
                       "relation_filter.start()",
 		      "UpdateGraphProcessor.DEFAULT.requestRefresh()"
                   ],
@@ -54,7 +54,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/by/sumby-plant-100m-static.json
+++ b/jobs/by/sumby-plant-100m-static.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('plant_id', 'Values')"
+                      "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['plant_id', 'Values'])"
                   ],
                   "timed" : 1
               },
@@ -40,9 +40,9 @@
                   "title" : "perform sumBy",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.sumBy('plant_id')",
+                      "result = relation.sum_by(by=['plant_id'])",
                       "time_end_ns = time.perf_counter_ns()",
-                      "processed_rows = relation.size()"
+                      "processed_rows = relation.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/comboagg/comboagg-bench-no-nulls-100m.json
+++ b/jobs/comboagg/comboagg-bench-no-nulls-100m.json
@@ -10,7 +10,7 @@
                   "text" : [
                       "import time",
                       "import deephaven.parquet as pt",
-                      "from deephaven import Aggregation as agg, as_list",
+                      "from deephaven import agg",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'comboagg-bench-' + tag",
                   ],
@@ -19,7 +19,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.read('/data/relation-' + tag + '.parquet').view('animal_id', 'adjective_id')",
+                  "text" : "relation = pt.read('/data/relation-' + tag + '.parquet').view(formulas=['animal_id', 'adjective_id'])",
                   "timed" : 1
               },
 
@@ -33,16 +33,16 @@
                   "title" : "perform ComboAgg",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.aggBy(as_list([\\",
-                      "  agg.AggSum('SumAdj=adjective_id'),\\",
-                      "  agg.AggMin('MinAdj=adjective_id'),\\",
-                      "  agg.AggMax('MaxAdj=adjective_id'),\\",
-                      "  agg.AggAvg('AvgAdj=adjective_id'),\\",
-                      "  agg.AggStd('StdAdj=adjective_id'),\\",
-                      "  agg.AggFirst('FirstAdj=adjective_id'),\\",
-                      "  agg.AggLast('LastAdj=adjective_id'),\\",
-                      "  agg.AggCount('CountAdj')\\",
-                      "]), 'animal_id')",
+                      "result = relation.agg_by([",
+                      "  agg.sum_('SumAdj=adjective_id'),",
+                      "  agg.min_('MinAdj=adjective_id'),",
+                      "  agg.max_('MaxAdj=adjective_id'),",
+                      "  agg.avg('AvgAdj=adjective_id'),",
+                      "  agg.std('StdAdj=adjective_id'),",
+                      "  agg.first('FirstAdj=adjective_id'),",
+                      "  agg.last('LastAdj=adjective_id'),",
+                      "  agg.count_('CountAdj')",
+                      "], by=['animal_id'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/common-tables-select.py
+++ b/jobs/common-tables-select.py
@@ -1,8 +1,8 @@
 # Assumes the variable 'tag' is defined in the environment.
 
-from deephaven.ParquetTools import readTable
+import deephaven.parquet as pt
 
-animals = readTable('/data/animals.parquet').select()
-adjectives = readTable('/data/adjectives.parquet').select()
-relation = readTable('/data/relation-' + str(tag) + '.parquet').select()
+animals = pt.read('/data/animals.parquet').select()
+adjectives = pt.read('/data/adjectives.parquet').select()
+relation = pt.read('/data/relation-' + str(tag) + '.parquet').select()
 

--- a/jobs/join/join-bench-100m.json
+++ b/jobs/join/join-bench-100m.json
@@ -31,7 +31,7 @@
                   "title" : "perform join",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.naturalJoin(adjectives, 'adjective_id').join(animals, 'animal_id').view('Values', 'adjective_name', 'animal_name')",
+                      "result = relation.natural_join(adjectives, on=['adjective_id']).join(animals, on=['animal_id']).view(formulas=['Values', 'adjective_name', 'animal_name'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/join/join-bench-1k.json
+++ b/jobs/join/join-bench-1k.json
@@ -31,7 +31,7 @@
                   "title" : "perform join",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.naturalJoin(adjectives, 'adjective_id').join(animals, 'animal_id').view('Values', 'adjective_name', 'animal_name')",
+                      "result = relation.natural_join(adjectives, on=['adjective_id']).join(animals, on=['animal_id']).view(formulas=['Values', 'adjective_name', 'animal_name'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/join/join-bench-no-nulls-100m.json
+++ b/jobs/join/join-bench-no-nulls-100m.json
@@ -31,7 +31,7 @@
                   "title" : "perform join",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.naturalJoin(adjectives, 'adjective_id').join(animals, 'animal_id').view('Values', 'adjective_name', 'animal_name')",
+                      "result = relation.natural_join(adjectives, on=['adjective_id']).join(animals, on=['animal_id']).view(formulas=['Values', 'adjective_name', 'animal_name'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/join/join-bench-no-nulls-1k.json
+++ b/jobs/join/join-bench-no-nulls-1k.json
@@ -31,7 +31,7 @@
                   "title" : "perform join",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.naturalJoin(adjectives, 'adjective_id').join(animals, 'animal_id').view('Values', 'adjective_name', 'animal_name')",
+                      "result = relation.natural_join(adjectives, on=['adjective_id']).join(animals, on=['animal_id']).view(formulas=['Values', 'adjective_name', 'animal_name'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/join/nj-100k-int.json
+++ b/jobs/join/nj-100k-int.json
@@ -2,7 +2,7 @@
   "benchmarks": [
     {
       "title": "Join 100m 100k words",
-      "generator_files": [ "100kwords.json", "animals.json", "adjectives.json", "100kwords.json", "relation-join.json" ],
+      "generator_files": [ "100kwords.json", "animals.json", "adjectives.json", "10kwords.json", "relation-join.json", "hex1mm.json" ],
       "benchmark": {
           "statements" : [
               {

--- a/jobs/join/nj-100k-str.json
+++ b/jobs/join/nj-100k-str.json
@@ -2,7 +2,7 @@
   "benchmarks": [
     {
       "title": "Join 100m 100k words",
-      "generator_files": [ "100kwords.json", "animals.json", "adjectives.json", "100kwords.json", "relation-join.json" ],
+      "generator_files": [ "100kwords.json", "animals.json", "adjectives.json", "10kwords.json", "relation-join.json", "hex1mm.json" ],
       "benchmark": {
           "statements" : [
               {

--- a/jobs/join/nj-1mm-int.json
+++ b/jobs/join/nj-1mm-int.json
@@ -2,7 +2,7 @@
   "benchmarks": [
     {
       "title": "Join 100m 1MM int",
-      "generator_files": [ "100kwords.json", "animals.json", "adjectives.json", "100kwords.json", "relation-join.json" , "hex1mm.json"],
+      "generator_files": [ "100kwords.json", "animals.json", "adjectives.json", "10kwords.json", "relation-join.json" , "hex1mm.json"],
       "benchmark": {
           "statements" : [
               {

--- a/jobs/join/nj-1mm-str.json
+++ b/jobs/join/nj-1mm-str.json
@@ -2,7 +2,7 @@
   "benchmarks": [
     {
       "title": "Join 100m 1MM strings",
-      "generator_files": [ "100kwords.json", "animals.json", "adjectives.json", "100kwords.json", "relation-join.json" , "hex1mm.json"],
+      "generator_files": [ "100kwords.json", "animals.json", "adjectives.json", "10kwords.json", "relation-join.json" , "hex1mm.json"],
       "benchmark": {
           "statements" : [
               {

--- a/jobs/join/nj-adjective-int.json
+++ b/jobs/join/nj-adjective-int.json
@@ -2,7 +2,7 @@
   "benchmarks": [
     {
       "title": "Join 100m adjective",
-      "generator_files": [ "100kwords.json", "animals.json", "adjectives.json", "10kwords.json", "relation-join.json" ],
+      "generator_files": [ "100kwords.json", "animals.json", "adjectives.json", "10kwords.json", "relation-join.json", "hex1mm.json" ],
       "benchmark": {
           "statements" : [
               {

--- a/jobs/join/nj-adjective-str.json
+++ b/jobs/join/nj-adjective-str.json
@@ -2,7 +2,7 @@
   "benchmarks": [
     {
       "title": "Join 100m adjective",
-      "generator_files": [ "100kwords.json", "animals.json", "adjectives.json", "animals.json", "relation-join.json" ],
+      "generator_files": [ "100kwords.json", "animals.json", "adjectives.json", "10kwords.json", "relation-join.json", "hex1mm.json" ],
       "benchmark": {
           "statements" : [
               {

--- a/jobs/join/nj-animal-int.json
+++ b/jobs/join/nj-animal-int.json
@@ -2,7 +2,7 @@
   "benchmarks": [
     {
       "title": "Join 100m animal",
-      "generator_files": [ "100kwords.json", "animals.json", "adjectives.json", "10kwords.json", "relation-join.json" ],
+      "generator_files": [ "100kwords.json", "animals.json", "adjectives.json", "10kwords.json", "relation-join.json", "hex1mm.json" ],
       "benchmark": {
           "statements" : [
               {

--- a/jobs/join/nj-animal-str.json
+++ b/jobs/join/nj-animal-str.json
@@ -2,7 +2,7 @@
   "benchmarks": [
     {
       "title": "Join 100m animal",
-      "generator_files": [ "100kwords.json", "animals.json", "adjectives.json", "animals.json", "relation-join.json" ],
+      "generator_files": [ "100kwords.json", "animals.json", "adjectives.json", "10kwords.json", "relation-join.json", "hex1mm.json" ],
       "benchmark": {
           "statements" : [
               {

--- a/jobs/readtable-select/readtable-select-100m.json
+++ b/jobs/readtable-select/readtable-select-100m.json
@@ -28,7 +28,7 @@
                       "time_start_ns = time.perf_counter_ns()",
                       "result = pt.read('/data/relation-' + str(tag) + '.parquet').select()",
                       "time_end_ns = time.perf_counter_ns()",
-                      "processed_rows = result.size()"
+                      "processed_rows = result.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/select-aj/select-aj-bench-no-nulls-100m-10k.json
+++ b/jobs/select-aj/select-aj-bench-no-nulls-100m-10k.json
@@ -9,6 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
+					  "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m-10k'",
                       "bench_name = 'select-aj-bench-' + tag",
                   ],
@@ -18,9 +19,8 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "from deephaven.ParquetTools import readTable", 
-                      "workqueue = readTable('/data/workqueue-no-nulls-100m.parquet').select()",
-                      "auditqueue = readTable('/data/auditqueue-no-nulls-10k.parquet').select()",
+                      "workqueue = pt.read('/data/workqueue-no-nulls-100m.parquet').select()",
+                      "auditqueue = pt.read('/data/auditqueue-no-nulls-10k.parquet').select()",
                   ],
                   "timed" : 1
               },
@@ -35,7 +35,7 @@
                   "title" : "perform aj",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = auditqueue.aj(workqueue, 'user_id, timestamp', 'work_timestamp = timestamp')",
+                      "result = auditqueue.aj(workqueue, on=['user_id', 'timestamp'], joins=['work_timestamp = timestamp'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/select-aj/select-aj-bench-no-nulls-100m-1m.json
+++ b/jobs/select-aj/select-aj-bench-no-nulls-100m-1m.json
@@ -9,6 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
+					  "import deephaven.parquet as pt",
                       "tag = 'no-nulls-100m-1m'",
                       "bench_name = 'select-aj-bench-' + tag",
                   ],
@@ -18,9 +19,8 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "from deephaven.ParquetTools import readTable", 
-                      "workqueue = readTable('/data/workqueue-no-nulls-100m.parquet').select()",
-                      "auditqueue = readTable('/data/auditqueue-no-nulls-1m.parquet').select()",
+                      "workqueue = pt.read('/data/workqueue-no-nulls-100m.parquet').select()",
+                      "auditqueue = pt.read('/data/auditqueue-no-nulls-1m.parquet').select()",
                   ],
                   "timed" : 1
               },
@@ -35,7 +35,7 @@
                   "title" : "perform aj",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = workqueue.aj(auditqueue, 'user_id, timestamp', 'audit_timestamp = timestamp')",
+                      "result = workqueue.aj(auditqueue, on=['user_id', 'timestamp'], joins=['audit_timestamp = timestamp'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/select-aj/select-aj-bench-no-nulls-1m-100m.json
+++ b/jobs/select-aj/select-aj-bench-no-nulls-1m-100m.json
@@ -9,6 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
+					  "import deephaven.parquet as pt",
                       "tag = 'no-nulls-1m-100m'",
                       "bench_name = 'select-aj-bench-' + tag",
                   ],
@@ -18,9 +19,8 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "from deephaven.ParquetTools import readTable", 
-                      "workqueue = readTable('/data/workqueue-no-nulls-100m.parquet').select()",
-                      "auditqueue = readTable('/data/auditqueue-no-nulls-1m.parquet').select()",
+                      "workqueue = pt.read('/data/workqueue-no-nulls-100m.parquet').select()",
+                      "auditqueue = pt.read('/data/auditqueue-no-nulls-1m.parquet').select()",
                   ],
                   "timed" : 1
               },
@@ -35,7 +35,7 @@
                   "title" : "perform aj",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = auditqueue.aj(workqueue, 'user_id, timestamp', 'work_timestamp = timestamp')",
+                      "result = auditqueue.aj(workqueue, on=['user_id', 'timestamp'], joins=['work_timestamp = timestamp'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/select-aj/select-aj-bench-no-nulls-1m-10k.json
+++ b/jobs/select-aj/select-aj-bench-no-nulls-1m-10k.json
@@ -9,6 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
+					  "import deephaven.parquet as pt",
                       "tag = 'no-nulls-1m-10k'",
                       "bench_name = 'select-aj-bench-' + tag",
                   ],
@@ -18,9 +19,8 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "from deephaven.ParquetTools import readTable", 
-                      "workqueue = readTable('/data/workqueue-no-nulls-1m.parquet').select()",
-                      "auditqueue = readTable('/data/auditqueue-no-nulls-10k.parquet').select()",
+                      "workqueue = pt.read('/data/workqueue-no-nulls-1m.parquet').select()",
+                      "auditqueue = pt.read('/data/auditqueue-no-nulls-10k.parquet').select()",
                   ],
                   "timed" : 1
               },
@@ -35,7 +35,7 @@
                   "title" : "perform aj",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = auditqueue.aj(workqueue, 'user_id, timestamp', 'work_timestamp = timestamp')",
+                      "result = auditqueue.aj(workqueue, on=['user_id', 'timestamp'], joins=['work_timestamp = timestamp'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/select-aj/select-aj-bench-no-nulls-no-by-100m-1m.json
+++ b/jobs/select-aj/select-aj-bench-no-nulls-no-by-100m-1m.json
@@ -9,6 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
+					  "import deephaven.parquet as pt",
                       "tag = 'no-nulls-no-by-100m-1m'",
                       "bench_name = 'select-aj-bench-' + tag",
                   ],
@@ -18,9 +19,8 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "from deephaven.ParquetTools import readTable", 
-                      "workqueue = readTable('/data/workqueue-no-nulls-100m.parquet').select()",
-                      "auditqueue = readTable('/data/auditqueue-no-nulls-1m.parquet').select()",
+                      "workqueue = pt.read('/data/workqueue-no-nulls-100m.parquet').select()",
+                      "auditqueue = pt.read('/data/auditqueue-no-nulls-1m.parquet').select()",
                   ],
                   "timed" : 1
               },
@@ -35,7 +35,7 @@
                   "title" : "perform aj",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = workqueue.aj(auditqueue, 'timestamp', 'audit_timestamp = timestamp')",
+                      "result = workqueue.aj(auditqueue, on=['timestamp'], joins=['audit_timestamp = timestamp'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/select-aj/select-aj-bench-no-nulls-no-by-1m-100m.json
+++ b/jobs/select-aj/select-aj-bench-no-nulls-no-by-1m-100m.json
@@ -9,6 +9,7 @@
                   "title" : "preamble",
                   "text" : [
                       "import time",
+					  "import deephaven.parquet as pt",
                       "tag = 'no-nulls-no-by-1m-100m'",
                       "bench_name = 'select-aj-bench-' + tag",
                   ],
@@ -18,9 +19,8 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "from deephaven.ParquetTools import readTable", 
-                      "workqueue = readTable('/data/workqueue-no-nulls-100m.parquet').select()",
-                      "auditqueue = readTable('/data/auditqueue-no-nulls-1m.parquet').select()",
+                      "workqueue = pt.read('/data/workqueue-no-nulls-100m.parquet').select()",
+                      "auditqueue = pt.read('/data/auditqueue-no-nulls-1m.parquet').select()",
                   ],
                   "timed" : 1
               },
@@ -35,7 +35,7 @@
                   "title" : "perform aj",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = auditqueue.aj(workqueue, 'timestamp', 'work_timestamp = timestamp')",
+                      "result = auditqueue.aj(workqueue, on=['timestamp'], joins=['work_timestamp = timestamp'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/select-by/select-by-bench-no-nulls-100m.json
+++ b/jobs/select-by/select-by-bench-no-nulls-100m.json
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'adjective_id')",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['animal_id', 'adjective_id'])",
                   "timed" : 1
               },
 
@@ -32,7 +32,7 @@
                   "title" : "perform countBy",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.countBy('count', 'animal_id')",
+                      "result = relation.count_by('count', by=['animal_id'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/select-by/select-by-bench-no-nulls-30m.json
+++ b/jobs/select-by/select-by-bench-no-nulls-30m.json
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select('animal_id', 'adjective_id')",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').select(formulas=['animal_id', 'adjective_id'])",
                   "timed" : 1
               },
 
@@ -32,7 +32,7 @@
                   "title" : "perform countBy",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.countBy('count', 'animal_id')",
+                      "result = relation.count_by('count', by=['animal_id'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/select-comboagg/select-comboagg-bench-no-nulls-100m.json
+++ b/jobs/select-comboagg/select-comboagg-bench-no-nulls-100m.json
@@ -10,7 +10,7 @@
                   "text" : [
                       "import time",
                       "import deephaven.parquet as pt",
-                      "from deephaven import Aggregation as agg, as_list",
+                      "from deephaven import agg",
                       "tag = 'no-nulls-100m'",
                       "bench_name = 'select-comboagg-bench-' + tag",
                   ],
@@ -19,7 +19,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.read('/data/relation-' + tag + '.parquet').select('animal_id', 'adjective_id')",
+                  "text" : "relation = pt.read('/data/relation-' + tag + '.parquet').select(formulas=['animal_id', 'adjective_id'])",
                   "timed" : 1
               },
 
@@ -33,7 +33,17 @@
                   "title" : "perform ComboAgg",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.aggBy(as_list([agg.AggSum('SumAdj=adjective_id'),agg.AggMin('MinAdj=adjective_id'), agg.AggMax('MaxAdj=adjective_id'), agg.AggAvg('AvgAdj=adjective_id'), agg.AggStd('StdAdj=adjective_id'), agg.AggFirst('FirstAdj=adjective_id'), agg.AggLast('LastAdj=adjective_id'), agg.AggCount('CountAdj')]), 'animal_id')",
+					  "aggs = [",
+					  "   agg.sum_('SumAdj=adjective_id'),",
+					  "   agg.min_('MinAdj=adjective_id'),", 
+					  "   agg.max_('MaxAdj=adjective_id'),", 
+					  "   agg.avg('AvgAdj=adjective_id'),", 
+					  "   agg.std('StdAdj=adjective_id'),", 
+					  "   agg.first('FirstAdj=adjective_id'),", 
+					  "   agg.last('LastAdj=adjective_id'),", 
+					  "   agg.count_('CountAdj')",
+					  "]",
+                      "result = relation.agg_by(aggs, 'animal_id')",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/select-join/select-join-bench-1k.json
+++ b/jobs/select-join/select-join-bench-1k.json
@@ -31,7 +31,7 @@
                   "title" : "perform join",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.naturalJoin(adjectives, 'adjective_id').join(animals, 'animal_id').view('Values', 'adjective_name', 'animal_name')",
+                      "result = relation.natural_join(adjectives, on=['adjective_id']).join(animals, on=['animal_id']).view(formulas=['Values', 'adjective_name', 'animal_name'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/select-join/select-join-bench-30m.json
+++ b/jobs/select-join/select-join-bench-30m.json
@@ -31,7 +31,7 @@
                   "title" : "perform join",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.naturalJoin(adjectives, 'adjective_id').join(animals, 'animal_id').view('Values', 'adjective_name', 'animal_name')",
+                      "result = relation.natural_join(adjectives, on=['adjective_id']).join(animals, on=['animal_id']).view(formulas=['Values', 'adjective_name', 'animal_name'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/select-join/select-join-bench-no-nulls-100m.json
+++ b/jobs/select-join/select-join-bench-no-nulls-100m.json
@@ -31,7 +31,7 @@
                   "title" : "perform join",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.naturalJoin(adjectives, 'adjective_id').join(animals, 'animal_id').view('Values', 'adjective_name', 'animal_name')",
+                      "result = relation.natural_join(adjectives, on=['adjective_id']).join(animals, on=['animal_id']).view(formulas=['Values', 'adjective_name', 'animal_name'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/select-join/select-join-bench-no-nulls-1k.json
+++ b/jobs/select-join/select-join-bench-no-nulls-1k.json
@@ -31,7 +31,7 @@
                   "title" : "perform join",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.naturalJoin(adjectives, 'adjective_id').join(animals, 'animal_id').view('Values', 'adjective_name', 'animal_name')",
+                      "result = relation.natural_join(adjectives, on=['adjective_id']).join(animals, on=['animal_id']).view(formulas=['Values', 'adjective_name', 'animal_name'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/select-join/select-join-bench-no-nulls-30m.json
+++ b/jobs/select-join/select-join-bench-no-nulls-30m.json
@@ -31,7 +31,7 @@
                   "title" : "perform join",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.naturalJoin(adjectives, 'adjective_id').join(animals, 'animal_id').view('Values', 'adjective_name', 'animal_name')",
+                      "result = relation.natural_join(adjectives, on=['adjective_id']).join(animals, on=['animal_id']).view(formulas=['Values', 'adjective_name', 'animal_name'])",
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/select-sort/select-sort-bench-no-nulls-10m.json
+++ b/jobs/select-sort/select-sort-bench-no-nulls-10m.json
@@ -18,7 +18,7 @@
 
               {
                   "title" : "load tables",
-                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').head(10_000_000).view('animal_id', 'adjective_id').select()",
+                  "text" : "relation = pt.read('/data/relation-' + str(tag) + '.parquet').head(10_000_000).view(formulas=['animal_id', 'adjective_id']).select()",
                   "timed" : 1
               },
 
@@ -32,7 +32,7 @@
                   "title" : "perform sort over earlier computed select",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.sort('animal_id', 'adjective_id')"
+                      "result = relation.sort(order_by=['animal_id', 'adjective_id'])"
                       "time_end_ns = time.perf_counter_ns()",
                   ],
                   "timed" : 1

--- a/jobs/select-update/select-update-bench-no-nulls-8-cols-100m.json
+++ b/jobs/select-update/select-update-bench-no-nulls-8-cols-100m.json
@@ -32,7 +32,17 @@
                   "title" : "perform update",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.update('vp1 = animal_id + adjective_id + 1', 'vp2 = animal_id + adjective_id + 2', 'vp3 = animal_id + adjective_id + 3', 'vp4 = animal_id + adjective_id + 4', 'vp5 = animal_id + adjective_id + 5', 'vp6 = animal_id + adjective_id + 6', 'vp7 = animal_id + adjective_id + 7', 'vp8 = animal_id + adjective_id + 8')"
+					  "formulas = [",
+					  "    'vp1 = animal_id + adjective_id + 1',",
+					  "    'vp2 = animal_id + adjective_id + 2',",
+					  "    'vp3 = animal_id + adjective_id + 3',",
+					  "    'vp4 = animal_id + adjective_id + 4',",
+					  "    'vp5 = animal_id + adjective_id + 5',",
+					  "    'vp6 = animal_id + adjective_id + 6',",
+					  "    'vp7 = animal_id + adjective_id + 7',",
+					  "    'vp8 = animal_id + adjective_id + 8'",
+					  "]",
+                      "result = relation.update(formulas)"
                       "time_end_ns = time.perf_counter_ns()"
                   ],
                   "timed" : 1

--- a/jobs/sort/sort-bench-no-nulls-10m-inc.json
+++ b/jobs/sort/sort-bench-no-nulls-10m-inc.json
@@ -25,7 +25,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-no-nulls-100m.parquet').head(10000000)",
+                      "relation = pt.read('/data/relation-no-nulls-10m.parquet')",
                       "autotune = jpy.get_type('io.deephaven.engine.table.impl.select.AutoTuningIncrementalReleaseFilter')",
                       "relation_filter = autotune(0, 1000000, 1.0, True)",
                       "relation_filtered = relation.where(relation_filter)"
@@ -53,7 +53,7 @@
                   "text" : [
                       "relation_filter.waitForCompletion()",
                       "elapsed_benchmark_nanos = relation_filter.durationNanos()",
-                      "processed_rows = result.size()"
+                      "processed_rows = result.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/sort/sort-bench-no-nulls-10m-static-repeat.json
+++ b/jobs/sort/sort-bench-no-nulls-10m-static-repeat.json
@@ -19,7 +19,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-no-nulls-100m.parquet').head(10000000)"
+                      "relation = pt.read('/data/relation-no-nulls-10m.parquet')"
                   ],
                   "timed" : 1
               },
@@ -35,9 +35,9 @@
                   "text" : [
                       "processed_rows = 0",
                       "time_start_ns = time.perf_counter_ns()",
-                      "for headSz in range(0, relation.size(), 500000):",
+                      "for headSz in range(0, relation.size, 500000):",
                       "     result = relation.head(headSz).sort('animal_id')",
-                      "     processed_rows += result.size()",
+                      "     processed_rows += result.size",
                       "time_end_ns = time.perf_counter_ns()"
                   ],
                   "timed" : 1

--- a/jobs/sort/sort-bench-no-nulls-10m-static.json
+++ b/jobs/sort/sort-bench-no-nulls-10m-static.json
@@ -19,7 +19,7 @@
               {
                   "title" : "load tables",
                   "text" : [
-                      "relation = pt.read('/data/relation-no-nulls-100m.parquet').head(10000000)",
+                      "relation = pt.read('/data/relation-no-nulls-10m.parquet')",
                   ],
                   "timed" : 1
               },
@@ -36,7 +36,7 @@
                       "time_start_ns = time.perf_counter_ns()",
                       "result = relation.sort('animal_id')",
                       "time_end_ns = time.perf_counter_ns()",
-                      "processed_rows = result.size()"
+                      "processed_rows = result.size"
                   ],
                   "timed" : 1
               },

--- a/jobs/update/update-bench-no-nulls-8-cols-100m.json
+++ b/jobs/update/update-bench-no-nulls-8-cols-100m.json
@@ -32,16 +32,17 @@
                   "title" : "perform update",
                   "text" : [
                       "time_start_ns = time.perf_counter_ns()",
-                      "result = relation.update(\\",
-                      "  'vp1 = animal_id + adjective_id + 1',\\",
-                      "  'vp2 = animal_id + adjective_id + 2',\\",
-                      "  'vp3 = animal_id + adjective_id + 3',\\",
-                      "  'vp4 = animal_id + adjective_id + 4',\\",
-                      "  'vp5 = animal_id + adjective_id + 5',\\",
-                      "  'vp6 = animal_id + adjective_id + 6',\\",
-                      "  'vp7 = animal_id + adjective_id + 7',\\",
-                      "  'vp8 = animal_id + adjective_id + 8'\\",
-                      ")"
+					  "formulas = [",
+					  "  'vp1 = animal_id + adjective_id + 1',",
+                      "  'vp2 = animal_id + adjective_id + 2',",
+                      "  'vp3 = animal_id + adjective_id + 3',",
+                      "  'vp4 = animal_id + adjective_id + 4',",
+                      "  'vp5 = animal_id + adjective_id + 5',",
+                      "  'vp6 = animal_id + adjective_id + 6',",
+                      "  'vp7 = animal_id + adjective_id + 7',",
+                      "  'vp8 = animal_id + adjective_id + 8'",
+					  "]",
+                      "result = relation.update(formulas)",
                       "time_end_ns = time.perf_counter_ns()"
                   ],
                   "timed" : 1


### PR DESCRIPTION
Went through all tests I could find in bencher, tested against 0.18.0, and fixed.  Didn't touch the panda tests.

I wasn't entirely sure about joins.  There were often two parameters, and I translated them to join(table, on=[param1], joins=[param2]).  Is that the intent?

There are still some tests that don't work. Any file that uses relation-manykeys-100m.json doesn't work because those generator files do not exist. Some examples can be found in the following.

./jobs/by/countby-filter-manykeys-100m-repeat.json
./jobs/by/comboby-manykeys-100m-static.json
./jobs/by/comboby-manykeys-100m-inc.json
./jobs/by/countby-manykeys-100m-static.json
./jobs/by/countby-filter-manykeys-100m-static.json
./jobs/by/countby-manykeys-100m-inc.json
./jobs/by/sumby-manykeys-100m-static.json
./jobs/by/combosum-manykeys-100m-static.json
./jobs/by/sumby-manykeys-100m-inc.json
./jobs/by/countby-manykeys-100m-repeat.json
./jobs/by/combosum-manykeys-100m-inc.json
./jobs/by/countby-filter-manykeys-100m-inc.json
